### PR TITLE
Fix sample code to work with SWResample 0.2

### DIFF
--- a/chapter1/pipeline.md
+++ b/chapter1/pipeline.md
@@ -72,7 +72,7 @@ Inside `handle_init`, we should define all elements and links between them. Firs
   children = [
     file_src: %Membrane.Element.File.Source{location: path_to_mp3},
     decoder: Membrane.Element.Mad.Decoder,
-    converter: %Membrane.Element.FFmpeg.SWResample.Converter{source_caps: %Membrane.Caps.Audio.Raw{sample_rate: 48_000, format: :s16le, channels: 2}},
+    converter: %Membrane.Element.FFmpeg.SWResample.Converter{output_caps: %Membrane.Caps.Audio.Raw{sample_rate: 48_000, format: :s16le, channels: 2}},
     sink: Membrane.Element.PortAudio.Sink,
   ]
 ```
@@ -112,7 +112,7 @@ defmodule Your.Module.Pipeline do
     children = [
       file_src: %Membrane.Element.File.Source{location: path_to_mp3},
       decoder: Membrane.Element.Mad.Decoder,
-      converter: %Membrane.Element.FFmpeg.SWResample.Converter{source_caps: %Membrane.Caps.Audio.Raw{sample_rate: 48000, format: :s16le, channels: 2}},
+      converter: %Membrane.Element.FFmpeg.SWResample.Converter{output_caps: %Membrane.Caps.Audio.Raw{sample_rate: 48000, format: :s16le, channels: 2}},
       sink: Membrane.Element.PortAudio.Sink,
     ]
 


### PR DESCRIPTION
The previous code failed to compile with the following error. 

```
== Compilation error in file lib/first_membrane_project/pipeline.ex ==
** (KeyError) key :source_caps not found
    expanding struct: Membrane.Element.FFmpeg.SWResample.Converter.__struct__/1
    lib/first_membrane_project/pipeline.ex:8: Project.Pipeline.handle_init/1
    (elixir) lib/kernel/parallel_compiler.ex:206: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/6
```