### PR TITLE
Update guide URLs to membrane.stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The Guide to the Membrane Framework
 
-This repo contains sources for the guide into Membrane. The guide is available [here](https://membraneframework.org/guide).
+This repo contains sources for the guide into Membrane. The guide is available [here](https://membrane.stream/guide).
 
-You may also want to visit our [website](https://membraneframework.org).
+You may also want to visit our [website](https://membrane.stream).
 
 The guide is generated with [ex_doc](https://github.com/elixir-lang/ex_doc).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,8 @@ A guide on how to release guide.
 
 The guide is published automatically by the CI.
 
-- contents of `https://membraneframework.org/guide` are taken from `landing` on branch `master`
-- the guide is deployed from generated `docs` from branches in form `vX.X(-X)`, e.g. `v0.5` or `v0.5-dev` and become available under `https://membraneframework.org/guide/vX.X(-X)`
+- contents of `https://membrane.stream/guide` are taken from `landing` on branch `master`
+- the guide is deployed from generated `docs` from branches in form `vX.X(-X)`, e.g. `v0.5` or `v0.5-dev` and become available under `https://membrane.stream/guide/vX.X(-X)`
 
 ## Publishing new version without bumping minor
 


### PR DESCRIPTION
https://membraneframework.org/guide redirects to https://membrane.stream, but not to the guide anymore.