### PR TITLE
Add source and sink driven by the erlang messages

### DIFF
--- a/livebook_examples/messages_source_and_sink/messages_source_and_sink.livemd
+++ b/livebook_examples/messages_source_and_sink/messages_source_and_sink.livemd
@@ -1,0 +1,135 @@
+# Messages source and sink
+
+## Section
+
+```elixir
+File.cd(__DIR__)
+Logger.configure(level: :error)
+
+Mix.install([
+  {:membrane_core, "~> 0.12.7"}
+])
+```
+
+```elixir
+defmodule MessageSource do
+  use Membrane.Source
+
+  def_output_pad(:output,
+    mode: :push,
+    accepted_format: _any
+  )
+
+  def_options(
+    sender: [
+      description: "PID of the process that will send messages with the bufers payload",
+      spec: pid()
+    ]
+  )
+
+  @impl true
+  def handle_init(_ctx, opts) do
+    send(opts.sender, {:hello_from_message_source, self()})
+    {[], %{sender: opts.sender, buffered: []}}
+  end
+
+  @impl true
+  def handle_playing(_ctx, state) do
+    {actions, state} = send_buffers(state)
+    {[stream_format: {:output, %Membrane.RemoteStream{type: :bytestream}}] ++ actions, state}
+  end
+
+  @impl true
+  def handle_info({:message, pid, message}, ctx, state) do
+    if pid == state.sender do
+      state = %{state | buffered: state.buffered ++ [message]}
+
+      if ctx.playback == :playing do
+        send_buffers(state)
+      else
+        {[], state}
+      end
+    else
+      {[], state}
+    end
+  end
+
+  @impl true
+  def handle_info(_msg, _ctx, state) do
+    {[], state}
+  end
+
+  defp send_buffers(state) do
+    actions =
+      Enum.map(state.buffered, fn message ->
+        {:buffer, {:output, %Membrane.Buffer{payload: message}}}
+      end)
+
+    {actions, %{state | buffered: []}}
+  end
+end
+```
+
+```elixir
+defmodule MessageSink do
+  use Membrane.Sink
+
+  def_input_pad(:input, mode: :push, accepted_format: _any)
+  def_options(receiver: [description: "PID of the process that will 
+    receive messages with the bufers payload", spec: pid()])
+
+  @impl true
+  def handle_init(_ctx, opts) do
+    {[], %{receiver: opts.receiver}}
+  end
+
+  @impl true
+  def handle_write(:input, buffer, _ctx, state) do
+    send(state.receiver, {:message, self(), buffer.payload})
+    {[], state}
+  end
+end
+```
+
+```elixir
+alias Membrane.RCPipeline
+import Membrane.ChildrenSpec
+
+structure =
+  child(:source, %MessageSource{sender: self()})
+  |> child(:sink, %MessageSink{receiver: self()})
+
+pipeline = RCPipeline.start!()
+RCPipeline.exec_actions(pipeline, spec: structure, playback: :playing)
+
+message_source_pid =
+  receive do
+    {:hello_from_message_source, message_source_pid} -> message_source_pid
+  end
+
+payloads = 1..10
+sender_pid = self()
+
+Task.async(fn ->
+  Enum.each(
+    payloads,
+    fn payload ->
+      send(message_source_pid, {:message, sender_pid, payload})
+    end
+  )
+end)
+
+defmodule Flusher do
+  def flush() do
+    receive do
+      msg ->
+        IO.inspect(msg)
+        flush()
+    after
+      0 -> :ok
+    end
+  end
+end
+
+Flusher.flush()
+```

--- a/livebook_examples/messages_source_and_sink/messages_source_and_sink.livemd
+++ b/livebook_examples/messages_source_and_sink/messages_source_and_sink.livemd
@@ -127,21 +127,11 @@ end)
 ## Printing of the messages received and pipeline termination
 
 ```elixir
-defmodule Flusher do
-  def flush() do
-    receive do
-      {:message, _pid, _value} = msg ->
-        IO.inspect(msg)
-        flush()
-
-      _other_msg ->
-        flush()
-    after
-      0 -> :ok
-    end
+for _i <- 1..10 do
+  receive do
+    {:message, _pid, _value} = msg -> IO.inspect(msg)
   end
 end
 
 RCPipeline.terminate(pipeline)
-Flusher.flush()
 ```

--- a/livebook_examples/messages_source_and_sink/messages_source_and_sink.livemd
+++ b/livebook_examples/messages_source_and_sink/messages_source_and_sink.livemd
@@ -1,7 +1,5 @@
 # Messages source and sink
 
-## Section
-
 ```elixir
 File.cd(__DIR__)
 Logger.configure(level: :error)
@@ -11,9 +9,13 @@ Mix.install([
 ])
 ```
 
+## Erlang messages driven source
+
 ```elixir
 defmodule MessageSource do
   use Membrane.Source
+
+  require Membrane.Logger
 
   def_output_pad(:output,
     mode: :push,
@@ -21,16 +23,16 @@ defmodule MessageSource do
   )
 
   def_options(
-    sender: [
-      description: "PID of the process that will send messages with the bufers payload",
-      spec: pid()
+    register_name: [
+      description: "The name under which the element's process will be registered",
+      spec: atom()
     ]
   )
 
   @impl true
   def handle_init(_ctx, opts) do
-    send(opts.sender, {:hello_from_message_source, self()})
-    {[], %{sender: opts.sender, buffered: []}}
+    Process.register(self(), opts.register_name)
+    {[], %{buffered: []}}
   end
 
   @impl true
@@ -40,22 +42,19 @@ defmodule MessageSource do
   end
 
   @impl true
-  def handle_info({:message, pid, message}, ctx, state) do
-    if pid == state.sender do
-      state = %{state | buffered: state.buffered ++ [message]}
+  def handle_info({:message, message}, ctx, state) do
+    state = %{state | buffered: state.buffered ++ [message]}
 
-      if ctx.playback == :playing do
-        send_buffers(state)
-      else
-        {[], state}
-      end
+    if ctx.playback == :playing do
+      send_buffers(state)
     else
       {[], state}
     end
   end
 
   @impl true
-  def handle_info(_msg, _ctx, state) do
+  def handle_info(msg, _ctx, state) do
+    Membrane.Logger.warning("Unknown message received: #{inspect(msg)}")
     {[], state}
   end
 
@@ -70,13 +69,15 @@ defmodule MessageSource do
 end
 ```
 
+## Erlang messages driven sink
+
 ```elixir
 defmodule MessageSink do
   use Membrane.Sink
 
   def_input_pad(:input, mode: :push, accepted_format: _any)
   def_options(receiver: [description: "PID of the process that will 
-    receive messages with the bufers payload", spec: pid()])
+    receive messages from the sink", spec: pid()])
 
   @impl true
   def handle_init(_ctx, opts) do
@@ -84,46 +85,56 @@ defmodule MessageSink do
   end
 
   @impl true
-  def handle_write(:input, buffer, _ctx, state) do
+  def handle_buffer(:input, buffer, _ctx, state) do
     send(state.receiver, {:message, self(), buffer.payload})
     {[], state}
   end
 end
 ```
 
+## Pipeline definition and startup
+
 ```elixir
 alias Membrane.RCPipeline
 import Membrane.ChildrenSpec
 
-structure =
-  child(:source, %MessageSource{sender: self()})
-  |> child(:sink, %MessageSink{receiver: self()})
+defmodule MyPipeline do
+  use Membrane.Pipeline
 
-pipeline = RCPipeline.start!()
-RCPipeline.exec_actions(pipeline, spec: structure, playback: :playing)
+  @impl true
+  def handle_init(_ctx, opts) do
+    spec =
+      child(:source, %MessageSource{register_name: :messages_source})
+      |> child(:sink, %MessageSink{receiver: Keyword.get(opts, :receiver)})
 
-message_source_pid =
-  receive do
-    {:hello_from_message_source, message_source_pid} -> message_source_pid
+    {[spec: spec], nil}
   end
+end
 
+{:ok, _supervisor, pipeline} = MyPipeline.start(receiver: self())
 payloads = 1..10
-sender_pid = self()
 
 Task.async(fn ->
   Enum.each(
     payloads,
-    fn payload ->
-      send(message_source_pid, {:message, sender_pid, payload})
-    end
+    &send(:messages_source, {:message, &1})
   )
 end)
 
+:ok
+```
+
+## Printing of the messages received and pipeline termination
+
+```elixir
 defmodule Flusher do
   def flush() do
     receive do
-      msg ->
+      {:message, _pid, _value} = msg ->
         IO.inspect(msg)
+        flush()
+
+      _other_msg ->
         flush()
     after
       0 -> :ok
@@ -131,5 +142,6 @@ defmodule Flusher do
   end
 end
 
+RCPipeline.terminate(pipeline)
 Flusher.flush()
 ```


### PR DESCRIPTION
This PR introduces POC of a Membrane:
* source sending buffer received as an erlang message
* sink sending payload of received buffers to the chosen process in an erlang message