### PR TITLE
Fix displayed `<br>`

### DIFF
--- a/guide/contributing_guide.md
+++ b/guide/contributing_guide.md
@@ -11,6 +11,7 @@ When contributing to existing repo:
 - create a PR from fork to our repo
 - await feedback from someone from the team
 - after passing the review, the PR will be merged
+
 <br>
 
 If you wish to create a new plugin you can give us a shout and if it's something we want as a part of our ecosystem we'll create a repo for you, guide you on your work and maintain the plugin in future. However, if feel confident enough to maintain it on your own, you can, of course, create your own repo and hex package - we only ask you to follow the naming conventions of the framework package and modules. In that case, don't forget to let us know about your work so we could include it on the list of available plugins.


### PR DESCRIPTION
Hello 👋 Small PR from my side

While browsing your guide I've noticed that there is a `<br>` displayed as a text [here](https://membrane.stream/guide/v0.9/contributing_guide.html#general-contribution-info)

<img width="541" alt="Screenshot 2023-08-03 at 11 33 09" src="https://github.com/membraneframework/guide/assets/56135216/9c28b329-49b1-40e2-8540-3ef3ef3dac1c">

Adding a newline above the tag seems to fix it 

<img width="542" alt="Screenshot 2023-08-03 at 11 34 22" src="https://github.com/membraneframework/guide/assets/56135216/122febe3-7d48-42c6-aa09-ac4e37da7962">
